### PR TITLE
Compile on Centos 7.0

### DIFF
--- a/src/CoreDumpWriter.c
+++ b/src/CoreDumpWriter.c
@@ -183,7 +183,8 @@ int WriteCoreDumpInternal(struct CoreDumpWriter *self)
         Log(error, "An error occured while generating the core dump");
                 
         // log gcore message and free up memory
-        for(int j = 0; j < i; j++){
+        int j;
+        for(j = 0; j < i; j++){
             if(outputBuffer[j] != NULL){
                 Log(error, "GCORE - %s", outputBuffer[j]);
                 free(outputBuffer[j]);

--- a/src/ProcDumpConfiguration.c
+++ b/src/ProcDumpConfiguration.c
@@ -458,7 +458,8 @@ int WaitForQuitOrEvent(struct ProcDumpConfiguration *self, struct Handle *handle
 int WaitForAllThreadsToTerminate(struct ProcDumpConfiguration *self)
 {
     int rc = 0;
-    for (int i = 0; i < self->nThreads; i++) {
+    int i;
+    for (i = 0; i < self->nThreads; i++) {
         if (rc = pthread_join(self->Threads[i], NULL) != 0) {
             Log(error, "An error occured while joining threads\n");
             exit(-1);
@@ -584,8 +585,9 @@ bool BeginMonitoring(struct ProcDumpConfiguration *self)
 bool IsValidNumberArg(const char *arg)
 {
     int strLen = strlen(arg);
+    int i;
 
-    for (int i = 0; i < strLen; i++) {
+    for (i = 0; i < strLen; i++) {
         if (!isdigit(arg[i]) && !isspace(arg[i])) {
             return false;
         }


### PR DESCRIPTION
Centos compilation complains about using -std=c99 for CFLAGS but adding that creates others errors. So this is the safest route to go