### PR TITLE
Add parentheses around assignments in conditionals

### DIFF
--- a/src/ProcDumpConfiguration.c
+++ b/src/ProcDumpConfiguration.c
@@ -334,23 +334,23 @@ int CreateTriggerThreads(struct ProcDumpConfiguration *self)
     int rc = 0;
     self->nThreads = 0;
 
-    if(rc=sigemptyset (&sigset) < 0)
+    if((rc=sigemptyset (&sigset)) < 0)
     {
         Trace("CreateTriggerThreads: sigemptyset failed.");
         return rc;
     }
-    if(rc=sigaddset (&sigset, SIGINT) < 0)
+    if((rc=sigaddset (&sigset, SIGINT)) < 0)
     {
         Trace("CreateTriggerThreads: sigaddset failed.");
         return rc;
     }
-    if(rc=sigaddset (&sigset, SIGTERM) < 0)
+    if((rc=sigaddset (&sigset, SIGTERM)) < 0)
     {
         Trace("CreateTriggerThreads: sigaddset failed.");
         return rc;
     }
 
-    if(rc = pthread_sigmask (SIG_BLOCK, &sigset, NULL) != 0)
+    if((rc = pthread_sigmask (SIG_BLOCK, &sigset, NULL)) != 0)
     {
         Trace("CreateTriggerThreads: pthread_sigmask failed.");
         return rc;
@@ -459,7 +459,7 @@ int WaitForAllThreadsToTerminate(struct ProcDumpConfiguration *self)
 {
     int rc = 0;
     for (int i = 0; i < self->nThreads; i++) {
-        if (rc = pthread_join(self->Threads[i], NULL) != 0) {
+        if ((rc = pthread_join(self->Threads[i], NULL)) != 0) {
             Log(error, "An error occured while joining threads\n");
             exit(-1);
         }


### PR DESCRIPTION
< and != have higher operator precedence than =

Signed-off-by: Michael Sartain <mikesart@fastmail.com>