### PR TITLE
Compile on CentOS - ifeq statement for checking if we're on CentOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 ROOT=.
 CC=gcc
-CFLAGS=-I ./include -pthread
+# If we are CentOS, then append -std=gnu99
+CENTOS := $(shell grep -ic CentOS /etc/redhat-release)
+ifeq ($(CENTOS),1)
+        CFLAGS=-I ./include -pthread -std=gnu99
+else
+        CFLAGS=-I ./include -pthread 
+endif
 LIBDIR=lib
 OBJDIR=obj
 SRCDIR=src


### PR DESCRIPTION
No source changes or changes to -std=c99 as that does not seem to work on CentOS/Fedora. -std=gnu99 works for centos and if not centos, default to the default compile options 