### PR TITLE
Implement waiting for process by name (-w parameter)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,14 @@ OBJDIR=obj
 SRCDIR=src
 INCDIR=include
 BINDIR=bin
+TESTDIR=tests/integration
 DEPS=$(wildcard $(INCDIR)/*.h)
 SRC=$(wildcard $(SRCDIR)/*.c)
+TESTSRC=$(wildcard $(TESTDIR)/*.c)
 OBJS=$(patsubst $(SRCDIR)/%.c, $(OBJDIR)/%.o, $(SRC))
+TESTOBJS=$(patsubst $(TESTDIR)/%.c, $(OBJDIR)/%.o, $(TESTSRC))
 OUT=$(BINDIR)/procdump
+TESTOUT=$(BINDIR)/ProcDumpTestApplication
 
 
 # installation directory
@@ -31,7 +35,7 @@ PKG_DEB=procdump_$(PKG_VERSION)_$(PKG_ARCH).deb
 
 all: clean build
 
-build: $(OBJDIR) $(BINDIR) $(OUT)
+build: $(OBJDIR) $(BINDIR) $(OUT) $(TESTOUT)
 
 install:
 	mkdir -p $(DESTDIR)$(INSTALLDIR)
@@ -42,7 +46,13 @@ install:
 $(OBJDIR)/%.o: $(SRCDIR)/%.c
 	$(CC) -c -g -o $@ $< $(CCFLAGS)
 
+$(OBJDIR)/%.o: $(TESTDIR)/%.c
+	$(CC) -c -g -o $@ $< $(CCFLAGS)
+
 $(OUT): $(OBJS)
+	$(CC) -o $@ $^ $(CCFLAGS)
+
+$(TESTOUT): $(TESTOBJS)
 	$(CC) -o $@ $^ $(CCFLAGS)
 
 $(OBJDIR):
@@ -55,7 +65,7 @@ clean:
 	-rm -rf $(OBJDIR)
 	-rm -rf $(BINDIR)
 	-rm -rf $(RELEASEDIR)
-	
+
 test: build
 	./tests/integration/run.sh
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Usage: procdump [OPTIONS...] TARGET
       -s          Consecutive seconds before dump is written (default is 10)
    TARGET must be exactly one of these:
       -p          pid of the process
+      -w          Name of the process executable
 ```
 ### Examples
 > The following examples all target a process with pid == 1234
@@ -109,6 +110,14 @@ The following will create a core dump when CPU usage is >= 65% or memory usage i
 ```
 sudo procdump -C 65 -M 100 -p 1234
 ```
+
+> All options can also be used with -w instead of -p. -w will wait for a process with the given name.
+
+The following waits for a process named `my_application` and creates a core dump immediately when it is found.
+```
+sudo procdump -w my_application
+```
+
 ## Current Limitations
 * Currently will only run on Linux Kernels version 3.5+
 * Does not have full feature parity with Windows version of ProcDump, specifically, stay alive functionality, and custom performance counters

--- a/include/ProcDumpConfiguration.h
+++ b/include/ProcDumpConfiguration.h
@@ -22,6 +22,7 @@
 #include <signal.h>
 #include <syslog.h>
 #include <limits.h>
+#include <dirent.h>
 
 #include "Handle.h"
 #include "TriggerThreadProcs.h"
@@ -70,6 +71,7 @@ struct ProcDumpConfiguration {
     int ThresholdSeconds;           // -s
     bool bTimerThreshold;           // -s
     int NumberOfDumpsToCollect;     // -n
+    bool WaitingForProcessName;     // -w
     bool DiagnosticsLoggingEnabled; // -d
 
     // multithreading
@@ -93,6 +95,7 @@ struct ProcDumpConfiguration {
 int GetOptions(struct ProcDumpConfiguration *self, int argc, char *argv[]);
 char * GetProcessName(pid_t pid);
 bool LookupProcessByPid(struct ProcDumpConfiguration *self);
+bool WaitForProcessName(struct ProcDumpConfiguration *self);
 int CreateProcessViaDebugThreadAndWaitUntilLaunched(struct ProcDumpConfiguration *self);
 int CreateTriggerThreads(struct ProcDumpConfiguration *self);
 int WaitForQuit(struct ProcDumpConfiguration *self, int milliseconds);

--- a/src/Procdump.c
+++ b/src/Procdump.c
@@ -31,6 +31,13 @@ int main(int argc, char *argv[])
         Log(warn, "Procdump not running with elevated credentials. If your uid does not match the uid of the target process procdump will not be able to capture memory dumps");
     }
 
+    // actively wait for the specified process name to start
+    if (g_config.WaitingForProcessName) {
+	if (WaitForProcessName(&g_config) == false) {
+            ExitProcDump();
+	}
+    }
+
     // start monitoring process
     if(CreateTriggerThreads(&g_config) != 0) {
         Log(error, INTERNAL_ERROR);

--- a/tests/integration/ProcDumpTestApplication.c
+++ b/tests/integration/ProcDumpTestApplication.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]){
+	if (argc > 1){
+		if (strcmp("sleep", argv[1]) == 0){
+			sleep(5);
+		} else if (strcmp("burn", argv[1]) == 0){
+			alarm(5);
+			while(1);
+		}
+	}
+}

--- a/tests/integration/runProcDumpAndValidate.sh
+++ b/tests/integration/runProcDumpAndValidate.sh
@@ -6,30 +6,40 @@ function runProcDumpAndValidate {
 	dumpDir=$(mktemp -d -t dump_XXXXXX)
 	cd $dumpDir
 
-        if [ "$5" == "MEM" ]; then
-            stress-ng --vm 1 --vm-hang 0 --vm-bytes $1 --timeout 20s -q&
-        else
-            stress-ng -c 1 -l $1 --timeout 20s -q&
-        fi
-	pid=$!
-	echo "PID: $pid"
+	if [ -z "$TESTPROGNAME" ]; then
+		if [ "$5" == "MEM" ]; then
+			stress-ng --vm 1 --vm-hang 0 --vm-bytes $1 --timeout 20s -q&
+		else
+			stress-ng -c 1 -l $1 --timeout 20s -q&
+		fi
+		pid=$!
+		echo "PID: $pid"
 
-	sleep 1s
+		sleep 1s
 
-	childrenpid=$(pidof -o $pid stress-ng) 
-        echo "ChildrenPID: $childrenpid"
+		childrenpid=$(pidof -o $pid stress-ng)
+			echo "ChildrenPID: $childrenpid"
 
-	childpid=$(echo $childrenpid | cut -d " " -f1)
-	echo "ChildPID: $childpid"
+		childpid=$(echo $childrenpid | cut -d " " -f1)
+		echo "ChildPID: $childpid"
 
-	echo "$PROCDUMPPATH $2 $3 -p $childpid"
-	$PROCDUMPPATH $2 $3 -p $childpid
+		echo "$PROCDUMPPATH $2 $3 -p $childpid"
+		$PROCDUMPPATH $2 $3 -p $childpid
+	else
+		TESTPROGPATH=$(readlink -m "$DIR/../../bin/$TESTPROGNAME");
+		(sleep 2; $TESTPROGPATH "$TESTPROGMODE") &
+		pid=$!
+		echo "PID: $pid"
+
+		echo "$PROCDUMPPATH $2 $3 -w $TESTPROGNAME"
+		$PROCDUMPPATH $2 $3 -w "$TESTPROGNAME"
+	fi
 
 	if ps -p $pid > /dev/null
 	then
 		kill $pid
 	fi
-	
+
 	if find "$dumpDir" -mindepth 1 -print -quit | grep -q .; then
 		if $4; then
 			exit 0

--- a/tests/integration/scenarios/high_cpu_by_name.sh
+++ b/tests/integration/scenarios/high_cpu_by_name.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
+runProcDumpAndValidate=$(readlink -m "$DIR/../runProcDumpAndValidate.sh");
+source $runProcDumpAndValidate
+
+TESTPROGNAME="ProcDumpTestApplication"
+TESTPROGMODE="burn"
+
+stressPercentage=90
+procDumpType="-C"
+procDumpTrigger=50
+shouldDump=true
+
+runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump

--- a/tests/integration/scenarios/low_cpu_by_name.sh
+++ b/tests/integration/scenarios/low_cpu_by_name.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
+runProcDumpAndValidate=$(readlink -m "$DIR/../runProcDumpAndValidate.sh");
+TESTPROGNAME="ProcDumpTestApplication"
+TESTPROGMODE="sleep"
+source $runProcDumpAndValidate
+
+stressPercentage=10
+procDumpType="-c"
+procDumpTrigger=20
+shouldDump=true
+
+runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump


### PR DESCRIPTION
This change implements the '-w' command line parameter to
allow waiting for a specific process name to launch as
proposed in #19.

This is done by looping over the `/proc/` filesystem and
comparing the names as returned by `GetProcessName` to the
name passed on the command line.

`GetProcessName` prints error messages if an error occurs -
as we're calling it a lot in `WaitForProcessName` instead of
once before, I added a new parameter to allow suppressing
the error messages while looping over `/proc/`.

Tests are done by running a small helper application 
which either sleeps or runs an endless loop for 5 seconds
and using the high/low CPU load triggers in combination
with `-w`. 