### PR TITLE
Document -w parameter in manpage (fix for #34)

### DIFF
--- a/procdump.1
+++ b/procdump.1
@@ -1,5 +1,5 @@
 .\" Manpage for procdump.
-.TH man 8 "12/18/2017" "1.0.1" "procdump manpage"
+.TH man 8 "10/08/2018" "1.0.1" "procdump manpage"
 .SH NAME
 procdump \- generate coredumps based off performance triggers.
 .SH SYNOPSIS
@@ -12,5 +12,6 @@ procdump [OPTIONS...] TARGET
       -s   Consecutive seconds before dump is written (default is 10)
   TARGET must be exactly one of these:
       -p   pid of the process
+      -w   Name of the process executable
 .SH DESCRIPTION
 procdump is a Linux reimagining of the class ProcDump tool from the Sysinternals suite of tools for Windows. Procdump provides a convenient way for Linux developers to create core dumps of their application based on performance triggers.


### PR DESCRIPTION
The new -w parameter was documented in the output of
`procdump -h` and in the README.md file but I forgot to add
it to the manual page.