### PR TITLE
resolve potential memory leak found by cppcheck

### DIFF
--- a/src/CoreDumpWriter.c
+++ b/src/CoreDumpWriter.c
@@ -224,6 +224,7 @@ int WriteCoreDumpInternal(struct CoreDumpWriter *self)
         }
     }
 
+    free(outputBuffer);
     return rc;
 }
 


### PR DESCRIPTION
[src/CoreDumpWriter.c:227]: (error) Memory leak: outputBuffer