### PR TITLE
Added support for .NET Core 3.x+ core dump generation that results in…

### DIFF
--- a/include/CoreDumpWriter.h
+++ b/include/CoreDumpWriter.h
@@ -27,6 +27,9 @@
 #define MAX_LINES 15
 #define BUFFER_LENGTH 1024
 
+#define CORECLR_DUMPTYPE_FULL 4
+#define CORECLR_DUMPLOGGING_OFF 0
+#define CORECLR_DIAG_IPCHEADER_SIZE 24
 
 // Magic version for the IpcHeader struct
 struct MagicVersion

--- a/include/CoreDumpWriter.h
+++ b/include/CoreDumpWriter.h
@@ -16,6 +16,9 @@
 #include <signal.h>
 #include <unistd.h>
 #include <sys/wait.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <stdint.h>
 
 #include "Handle.h"
 #include "ProcDumpConfiguration.h"
@@ -23,6 +26,30 @@
 #define DATE_LENGTH 26
 #define MAX_LINES 15
 #define BUFFER_LENGTH 1024
+
+
+// Magic version for the IpcHeader struct
+struct MagicVersion
+{
+    uint8_t Magic[14];
+};
+
+// The header to be associated with every command and response
+// to/from the diagnostics server
+struct IpcHeader
+{
+    union
+    {
+        struct MagicVersion _magic;
+        uint8_t  Magic[14];  // Magic Version number; a 0 terminated char array
+    };
+
+    uint16_t Size;       // The size of the incoming packet, size = header + payload size
+    uint8_t  CommandSet; // The scope of the Command.
+    uint8_t  CommandId;  // The command being sent
+    uint16_t Reserved;   // reserved for future use
+};
+
 
 enum ECoreDumpType {
     COMMIT,

--- a/include/CoreDumpWriter.h
+++ b/include/CoreDumpWriter.h
@@ -41,7 +41,7 @@ struct IpcHeader
     union
     {
         struct MagicVersion _magic;
-        uint8_t  Magic[14];  // Magic Version number; a 0 terminated char array
+        uint8_t  Magic[14];  // Magic Version number
     };
 
     uint16_t Size;       // The size of the incoming packet, size = header + payload size

--- a/src/CoreDumpWriter.c
+++ b/src/CoreDumpWriter.c
@@ -288,7 +288,6 @@ bool GenerateCoreClrDump(char* socketName, char* dumpFileName)
             }
             else
             {   
-                // Get the payload and payload size
                 unsigned int dumpFileNameLen = ((strlen(dumpFileName)+1));//*sizeof(wchar_t);
                 int payloadSize = sizeof(dumpFileNameLen);
                 payloadSize += dumpFileNameLen*sizeof(wchar_t);

--- a/src/CoreDumpWriter.c
+++ b/src/CoreDumpWriter.c
@@ -470,7 +470,8 @@ int WriteCoreDumpInternal(struct CoreDumpWriter *self, char* socketName)
                 rc = 1;
             }
         }
-        
+
+        free(outputBuffer);
     }
     else
     {

--- a/src/CoreDumpWriter.c
+++ b/src/CoreDumpWriter.c
@@ -14,8 +14,15 @@ char *sanitize(char *processName);
 
 static const char *CoreDumpTypeStrings[] = { "commit", "cpu", "time", "manual" };
 
-int WriteCoreDumpInternal(struct CoreDumpWriter *self);
+bool GenerateCoreClrDump(char* socketName, char* dumpFileName);
+bool IsCoreClrProcess(struct CoreDumpWriter *self, char** socketName);
+char* GetPath(char* lineBuf);
+uint16_t* GetUint16(char* buffer);
+
+int WriteCoreDumpInternal(struct CoreDumpWriter *self, char* socketName);
 FILE *popen2(const char *command, const char *type, pid_t *pid);
+
+extern const struct IpcHeader GenericSuccessHeader;
 
 //--------------------------------------------------------------------
 //
@@ -38,6 +45,127 @@ struct CoreDumpWriter *NewCoreDumpWriter(enum ECoreDumpType type, struct ProcDum
 
     return writer;
 }
+
+
+//--------------------------------------------------------------------
+//
+// GetPath - Parses out the path from a full line read from 
+//           /proc/net/unix. Example line:
+//
+//           0000000000000000: 00000003 00000000 00000000 0001 03 20287 @/tmp/.X11-unix/X0
+//
+// Returns: path   - point to path if it exists, NULL otherwise. 
+//
+//--------------------------------------------------------------------
+char* GetPath(char* lineBuf)
+{
+    char delim[] = " ";
+
+    // example of /proc/net/unix line:
+    // 0000000000000000: 00000003 00000000 00000000 0001 03 20287 @/tmp/.X11-unix/X0
+    char *ptr = strtok(lineBuf, delim);
+    
+    // Move to last column which contains the name of the file (/socket)
+    for(int i=0; i<7; i++) 
+    {
+        ptr = strtok(NULL, delim);
+    }
+
+    if(ptr!=NULL)
+    {
+        ptr[strlen(ptr)-1]='\0';
+    }
+
+    return ptr;
+}
+
+//--------------------------------------------------------------------
+//
+// IsCoreClrProcess - Checks to see whether the process is a .NET Core
+// process by checking the availability of a diagnostics server exposed
+// as a Unix domain socket. If the pipe is available, we assume its a 
+// .NET Core process
+//
+// Returns: true   - if the process is a .NET Core process,[out] socketName
+//                   will contain the full socket name. Caller owns the 
+//                   memory allocated for the socketName
+//          false  - if the process is NOT a .NET Core process,[out] socketName
+//                   will be NULL.
+//
+//--------------------------------------------------------------------
+bool IsCoreClrProcess(struct CoreDumpWriter *self, char** socketName)
+{
+    bool bRet = false;
+    *socketName = NULL;
+    FILE *procFile = NULL;
+    char lineBuf[4096];
+    char tmpFolder[4096]; 
+    char* prefixTmpFolder = NULL; 
+
+    // If $TMPDIR is set, use it as the path, otherwise we use /tmp
+    // per https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+    prefixTmpFolder = getenv("TMPDIR");
+    if(prefixTmpFolder==NULL)
+    {
+        snprintf(tmpFolder, 4096, "/tmp/dotnet-diagnostic-%d", self->Config->ProcessId);
+    }
+    else
+    {
+        strncpy(tmpFolder, prefixTmpFolder, 4096);
+    }
+    
+    // Enumerate all open domain sockets exposed from the process. If one
+    // exists by the following prefix, we assume its a .NET Core process:
+    //    dotnet-diagnostic-{%d:PID}
+    // The sockets are found in /proc/net/unix
+    procFile = fopen("/proc/net/unix", "r");
+    if(procFile != NULL)
+    {
+        fgets(lineBuf, sizeof(lineBuf), procFile); // Skip first line with column headers. 
+
+        while(fgets(lineBuf, 4096, procFile) != NULL)
+        {
+            char* ptr = GetPath(lineBuf);
+            if(ptr!=NULL)            
+            {
+                if(strncmp(ptr, tmpFolder, strlen(tmpFolder)) == 0)
+                {
+                    // Found the correct socket...copy the name to the out param
+                    *socketName = malloc(sizeof(char)*strlen(ptr)+1);
+                    if(*socketName!=NULL)
+                    {
+                        memset(*socketName, 0, sizeof(char)*strlen(ptr)+1);
+                        if(strncpy(*socketName, ptr, sizeof(char)*strlen(ptr)+1)!=NULL)
+                        {
+                            // TODO: Log the socket name
+                            bRet = true;
+                        }
+                        break;                        
+                    }
+                } 
+            }
+        }
+    }
+    else
+    {
+        Trace("Failed to open /proc/net/unix [%d].", errno);
+    }
+
+    if(procFile!=NULL)
+    {
+        fclose(procFile);
+        procFile = NULL;
+    }
+
+    if(*socketName!=NULL && bRet==false)
+    {
+        free(*socketName);
+        *socketName = NULL; 
+    }
+
+    return bRet; 
+}
+
 
 //--------------------------------------------------------------------
 //
@@ -70,13 +198,19 @@ int WriteCoreDump(struct CoreDumpWriter *self)
         case WAIT_OBJECT_0: // QUIT!  Time for cleanup, no dump
             break;
         case WAIT_OBJECT_0+1: // We got a dump slot!
-            if ((rc = WriteCoreDumpInternal(self)) == 0) {
-                // We're done here, unlock (increment) the sem
-                if(sem_post(&self->Config->semAvailableDumpSlots.semaphore) == -1){
-                    Log(error, INTERNAL_ERROR);
-                    Trace("WriteCoreDump: failed sem_post.");
-                    exit(-1);
+            { 
+                char* socketName = NULL;
+                IsCoreClrProcess(self, &socketName);
+                if ((rc = WriteCoreDumpInternal(self, socketName)) == 0) {
+                    // We're done here, unlock (increment) the sem
+                    if(sem_post(&self->Config->semAvailableDumpSlots.semaphore) == -1){
+                        Log(error, INTERNAL_ERROR);
+                        Trace("WriteCoreDump: failed sem_post.");
+                        if(socketName) free(socketName);
+                        exit(-1);
+                    }
                 }
+                if(socketName) free(socketName);
             }
             break;
         case WAIT_ABANDONED: // We've hit the dump limit, clean up
@@ -94,12 +228,179 @@ int WriteCoreDump(struct CoreDumpWriter *self)
     return rc;
 }
 
+//--------------------------------------------------------------------
+//
+// GetUint16 - Quick and dirty conversion from char to uint16_t 
+//
+// Returns: uint16_t*   - if successfully converted, NULL otherwise.
+//                        Caller must free upon success
+//
+//--------------------------------------------------------------------
+uint16_t* GetUint16(char* buffer)
+{
+    uint16_t* dumpFileNameW = NULL;
+
+    if(buffer!=NULL)
+    {
+        dumpFileNameW = malloc((strlen(buffer)+1)*sizeof(uint16_t));
+        for(int i=0; i<(strlen(buffer)+1); i++)
+        {
+            dumpFileNameW[i] = (uint16_t) buffer[i];
+        }
+    }
+
+    return dumpFileNameW;
+}
+
+//--------------------------------------------------------------------
+//
+// GenerateCoreClrDump - Generates the .NET core dump using the
+// diagnostics server. 
+//
+// Returns: true   - if core dump was generated
+//          false  - otherwise
+//
+//--------------------------------------------------------------------
+bool GenerateCoreClrDump(char* socketName, char* dumpFileName)
+{
+    bool bRet = false;
+    struct sockaddr_un addr = {0};
+    int fd = 0;
+    uint16_t* dumpFileNameW = NULL;
+    void* temp_buffer = NULL;
+
+    if( (dumpFileNameW = GetUint16(dumpFileName))!=NULL)
+    {
+        if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
+        {
+            Trace("Failed to create socket for .NET Core dump generation.");
+        }
+        else
+        {
+            // Create socket to diagnostics server
+            memset(&addr, 0, sizeof(struct sockaddr_un));
+            addr.sun_family = AF_UNIX;
+            strncpy(addr.sun_path, socketName, sizeof(addr.sun_path)-1);
+
+            if (connect(fd, (struct sockaddr*)&addr, sizeof(struct sockaddr_un)) == -1)
+            {
+                Trace("Failed to connect to socket for .NET Core dump generation.");
+            }
+            else
+            {   
+                // Get the payload and payload size
+                unsigned int dumpFileNameLen = ((strlen(dumpFileName)+1));//*sizeof(wchar_t);
+                int payloadSize = sizeof(dumpFileNameLen);
+                payloadSize += dumpFileNameLen*sizeof(wchar_t);
+                unsigned int dumpType = 4;          // 4 = full dump
+                payloadSize += sizeof(dumpType);     
+                unsigned int diagnostics = 0;       // 0 = turn off console logging. Unfortunately this still logs some stuff
+                payloadSize += sizeof(diagnostics);     
+                
+                uint16_t totalPacketSize = sizeof(struct IpcHeader)+payloadSize;
+
+                // First initialize header
+                temp_buffer = malloc(totalPacketSize);
+                if(temp_buffer!=NULL)
+                {
+                    struct IpcHeader dumpHeader =
+                    {
+                        { {"DOTNET_IPC_V1"} },
+                        (uint16_t)totalPacketSize,
+                        (uint8_t)0x01,
+                        (uint8_t)0x01,
+                        (uint16_t)0x0000
+                    };
+
+                    void* temp_buffer_cur = temp_buffer;
+
+                    memcpy(temp_buffer_cur, &dumpHeader, sizeof(struct IpcHeader));     
+                    temp_buffer_cur += sizeof(struct IpcHeader);
+
+                    // Now we add the payload 
+                    memcpy(temp_buffer_cur, &dumpFileNameLen, sizeof(dumpFileNameLen));
+                    temp_buffer_cur += sizeof(dumpFileNameLen);
+
+                    memcpy(temp_buffer_cur, dumpFileNameW, dumpFileNameLen*sizeof(uint16_t));     
+                    temp_buffer_cur += dumpFileNameLen*sizeof(uint16_t);
+
+                    // next, the dumpType
+                    memcpy(temp_buffer_cur, &dumpType, sizeof(unsigned int));     
+                    temp_buffer_cur += sizeof(unsigned int);
+
+                    // next, the diagnostics flag
+                    memcpy(temp_buffer_cur, &diagnostics, sizeof(unsigned int));     
+
+                    if(send(fd, temp_buffer, totalPacketSize, 0)==-1)
+                    {
+                        Trace("Failed sending packet to diagnostics server [%d]", errno);
+                    }
+                    else
+                    {
+                        // Lets get the header first
+                        struct IpcHeader retHeader; 
+                        if(recv(fd, &retHeader, sizeof(struct IpcHeader), 0)==-1)
+                        {
+                            Trace("Failed receiving response header from diagnostics server [%d]", errno);
+                        }
+                        else
+                        {
+                            // Check the header to make sure its the right size
+                            if(retHeader.Size != 24)
+                            {
+                                Trace("Failed validating header size in response header from diagnostics server [%d != 24]", retHeader.Size);
+                            }
+                            else
+                            {
+                                // Next, get the payload which contains a single uint32 (hresult)
+                                int32_t res = -1; 
+                                if(recv(fd, &res, sizeof(int32_t), 0)==-1)
+                                {
+                                    Trace("Failed receiving result code from response payload from diagnostics server [%d]", errno);
+                                }
+                                else
+                                {
+                                    if(res==0) 
+                                    {
+                                        bRet = true; 
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+    if(temp_buffer!=NULL)
+    {
+        free(temp_buffer);
+        temp_buffer = NULL;
+    }
+
+    if(fd!=0)
+    {
+        close(fd);
+        fd = 0;
+    }
+    
+    if(dumpFileNameW!=NULL)
+    {
+        free(dumpFileNameW);
+        dumpFileNameW = NULL;
+    }
+
+    return bRet;
+}
+
 /// CRITICAL SECTION
 /// Should only ever have <max number of dump slots> running concurrently
 /// The default value of which is 1 (hard coded) and is set in
 /// ProcDumpConfiguration.semAvailableDumpSlots
 /// Returns 1 if we trigger quit in the crit section, 0 otherwise
-int WriteCoreDumpInternal(struct CoreDumpWriter *self)
+int WriteCoreDumpInternal(struct CoreDumpWriter *self, char* socketName)
 {
     char date[DATE_LENGTH];
     char command[BUFFER_LENGTH];
@@ -150,74 +451,98 @@ int WriteCoreDumpInternal(struct CoreDumpWriter *self)
         exit(-1);
     }
 
-    // generate core dump for given process
-    commandPipe = popen2(command, "r", &gcorePid);
-    self->Config->gcorePid = gcorePid;
-    
-    if(commandPipe == NULL){
-        Log(error, "An error occured while generating the core dump");      
-        Trace("WriteCoreDumpInternal: Failed to open pipe to gcore");
-        exit(1);
-    }
-    
-    // read all output from gcore command
-    for(i = 0; i < MAX_LINES && fgets(lineBuffer, sizeof(lineBuffer), commandPipe) != NULL; i++) {
-        lineLength = strlen(lineBuffer);                                // get # of characters read
-
-        outputBuffer[i] = (char*)malloc(sizeof(char) * lineLength);
-        if(outputBuffer[i] != NULL) {
-            strncpy(outputBuffer[i], lineBuffer, lineLength - 1);           // trim newline off
-            outputBuffer[i][lineLength-1] = '\0';                           // append null character
+    if(socketName!=NULL)
+    {
+        // If we have a socket name, we're dumping a .NET Core 3+ process....
+        if(GenerateCoreClrDump(socketName, coreDumpFileName)==false)
+        {
+            Log(error, "An error occured while generating the core dump for .NET 3.x+ process");
         }
-        else {
-            Log(error, INTERNAL_ERROR);
-            Trace("WriteCoreDumpInternal: failed to allocate gcore error message buffer");
-            exit(-1);
-        }
-    }
-    
-    // close pipe reading from gcore
-    self->Config->gcorePid = NO_PID;                // reset gcore pid so that signal handler knows we aren't dumping
-    pclose(commandPipe);
+        else
+        {
+            // log out sucessful core dump generated
+            Log(info, "Core dump %d generated: %s", self->Config->NumberOfDumpsCollected, coreDumpFileName);
 
-    // check if gcore was able to generate the dump
-    if(strstr(outputBuffer[i-1], "gcore: failed") != NULL){
-        Log(error, "An error occured while generating the core dump");
-                
-        // log gcore message
-        for(int j = 0; j < i; j++){
-            if(outputBuffer[j] != NULL){
-                Log(error, "GCORE - %s", outputBuffer[j]);
+            self->Config->NumberOfDumpsCollected++; // safe to increment in crit section
+            if (self->Config->NumberOfDumpsCollected >= self->Config->NumberOfDumpsToCollect) {
+                SetEvent(&self->Config->evtQuit.event); // shut it down, we're done here
+                rc = 1;
             }
         }
-
-        exit(1);
+        
     }
+    else
+    {
+        // Oterwise, we use gcore dump generation   TODO: We might consider adding a forcegcore flag in cases where
+        // someone wants to use gcore even for .NET Core 3.x+ processes.
+        commandPipe = popen2(command, "r", &gcorePid);
+        self->Config->gcorePid = gcorePid;
+        
+        if(commandPipe == NULL){
+            Log(error, "An error occured while generating the core dump");      
+            Trace("WriteCoreDumpInternal: Failed to open pipe to gcore");
+            exit(1);
+        }
+        
+        // read all output from gcore command
+        for(i = 0; i < MAX_LINES && fgets(lineBuffer, sizeof(lineBuffer), commandPipe) != NULL; i++) {
+            lineLength = strlen(lineBuffer);                                // get # of characters read
 
-    for(int j = 0; j < i; j++) {
-        free(outputBuffer[j]);
-    }
-    free(outputBuffer);
-
-    self->Config->NumberOfDumpsCollected++; // safe to increment in crit section
-    if (self->Config->NumberOfDumpsCollected >= self->Config->NumberOfDumpsToCollect) {
-        SetEvent(&self->Config->evtQuit.event); // shut it down, we're done here
-        rc = 1;
-    }
-
-    // validate that core dump file was generated
-    if(access(coreDumpFileName, F_OK) != -1) {
-        if(self->Config->nQuit){
-            // if we are in a quit state from interrupt delete partially generated core dump file
-            int ret = unlink(coreDumpFileName);
-            if (ret < 0 && errno != ENOENT) {
-                Trace("WriteCoreDumpInternal: Failed to remove partial core dump");
+            outputBuffer[i] = (char*)malloc(sizeof(char) * lineLength);
+            if(outputBuffer[i] != NULL) {
+                strncpy(outputBuffer[i], lineBuffer, lineLength - 1);           // trim newline off
+                outputBuffer[i][lineLength-1] = '\0';                           // append null character
+            }
+            else {
+                Log(error, INTERNAL_ERROR);
+                Trace("WriteCoreDumpInternal: failed to allocate gcore error message buffer");
                 exit(-1);
             }
         }
-        else{
-            // log out sucessful core dump generated
-            Log(info, "Core dump %d generated: %s", self->Config->NumberOfDumpsCollected, coreDumpFileName);
+        
+        // close pipe reading from gcore
+        self->Config->gcorePid = NO_PID;                // reset gcore pid so that signal handler knows we aren't dumping
+        pclose(commandPipe);
+
+        // check if gcore was able to generate the dump
+        if(strstr(outputBuffer[i-1], "gcore: failed") != NULL){
+            Log(error, "An error occured while generating the core dump");
+                    
+            // log gcore message
+            for(int j = 0; j < i; j++){
+                if(outputBuffer[j] != NULL){
+                    Log(error, "GCORE - %s", outputBuffer[j]);
+                }
+            }
+
+            exit(1);
+        }
+
+        for(int j = 0; j < i; j++) {
+            free(outputBuffer[j]);
+        }
+        free(outputBuffer);
+
+        // validate that core dump file was generated
+        if(access(coreDumpFileName, F_OK) != -1) {
+            if(self->Config->nQuit){
+                // if we are in a quit state from interrupt delete partially generated core dump file
+                int ret = unlink(coreDumpFileName);
+                if (ret < 0 && errno != ENOENT) {
+                    Trace("WriteCoreDumpInternal: Failed to remove partial core dump");
+                    exit(-1);
+                }
+            }
+            else{
+                // log out sucessful core dump generated
+                Log(info, "Core dump %d generated: %s", self->Config->NumberOfDumpsCollected, coreDumpFileName);
+
+                self->Config->NumberOfDumpsCollected++; // safe to increment in crit section
+                if (self->Config->NumberOfDumpsCollected >= self->Config->NumberOfDumpsToCollect) {
+                    SetEvent(&self->Config->evtQuit.event); // shut it down, we're done here
+                    rc = 1;
+                }
+            }
         }
     }
 

--- a/src/CoreDumpWriter.c
+++ b/src/CoreDumpWriter.c
@@ -137,7 +137,7 @@ bool IsCoreClrProcess(struct CoreDumpWriter *self, char** socketName)
                         memset(*socketName, 0, sizeof(char)*strlen(ptr)+1);
                         if(strncpy(*socketName, ptr, sizeof(char)*strlen(ptr)+1)!=NULL)
                         {
-                            // TODO: Log the socket name
+                            Trace("CoreCLR diagnostics socket: %s", socketName);
                             bRet = true;
                         }
                         break;                        
@@ -288,12 +288,12 @@ bool GenerateCoreClrDump(char* socketName, char* dumpFileName)
             }
             else
             {   
-                unsigned int dumpFileNameLen = ((strlen(dumpFileName)+1));//*sizeof(wchar_t);
+                unsigned int dumpFileNameLen = ((strlen(dumpFileName)+1));
                 int payloadSize = sizeof(dumpFileNameLen);
                 payloadSize += dumpFileNameLen*sizeof(wchar_t);
-                unsigned int dumpType = 4;          // 4 = full dump
+                unsigned int dumpType = CORECLR_DUMPTYPE_FULL;
                 payloadSize += sizeof(dumpType);     
-                unsigned int diagnostics = 0;       // 0 = turn off console logging. Unfortunately this still logs some stuff
+                unsigned int diagnostics = CORECLR_DUMPLOGGING_OFF;       
                 payloadSize += sizeof(diagnostics);     
                 
                 uint16_t totalPacketSize = sizeof(struct IpcHeader)+payloadSize;
@@ -346,7 +346,7 @@ bool GenerateCoreClrDump(char* socketName, char* dumpFileName)
                         else
                         {
                             // Check the header to make sure its the right size
-                            if(retHeader.Size != 24)
+                            if(retHeader.Size != CORECLR_DIAG_IPCHEADER_SIZE)
                             {
                                 Trace("Failed validating header size in response header from diagnostics server [%d != 24]", retHeader.Size);
                             }

--- a/src/CoreDumpWriter.c
+++ b/src/CoreDumpWriter.c
@@ -303,6 +303,7 @@ bool GenerateCoreClrDump(char* socketName, char* dumpFileName)
                 temp_buffer = malloc(totalPacketSize);
                 if(temp_buffer!=NULL)
                 {
+                    memset(temp_buffer, 0, totalPacketSize);
                     struct IpcHeader dumpHeader =
                     {
                         { {"DOTNET_IPC_V1"} },


### PR DESCRIPTION
… more manageable core dump sizes

A few notes on this PR:

1. Due to the requirement of the diagnostics server and how it expects strings to be encoded, I am crudely converting from char to uint16_t by straight casts. We may have to revisit in unicode scenarios. 

2. We may in a later change include a flag (such as forcegcore) to bypass the diagnostics server for .net core processes. Not sure how viable that scenario is but we'll see. 

3. The diagnostics socket path is either in $TMPDIR or hardcoded /tmp. If a user has $TMPDIR defined she will have to run sudo **-E** <procdump ....> in order for procdump to see the TMPDIR env variable.  