### PR TITLE
Auto-Versioning Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ TESTOBJS=$(patsubst $(TESTDIR)/%.c, $(OBJDIR)/%.o, $(TESTSRC))
 OUT=$(BINDIR)/procdump
 TESTOUT=$(BINDIR)/ProcDumpTestApplication
 
+# Revision value from build pipeline
+REVISION:=$(if $(REVISION),$(REVISION),'99999')
 
 # installation directory
 DESTDIR ?= /
@@ -82,7 +84,7 @@ tarball:
 
 .PHONY: deb
 deb: tarball
-	debbuild --define='_Revision ${Revision}' $(PKGBUILDFLAGS) $(BUILDDIR)/SPECS/procdump.spec
+	debbuild --define='_Revision ${REVISION}' $(PKGBUILDFLAGS) $(BUILDDIR)/SPECS/procdump.spec
 
 .PHONY: rpm
 rpm: tarball

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,14 +34,13 @@ jobs:
     condition: not(eq(variables['Build.Reason'], 'PullRequest'))
     dependsOn:
       - Run_Unit_Tests
-    variables:
-      Revision: '$(Build.BuildId)'
     steps:
     - script: |
         make
       displayName: 'Build procdump Ubuntu'
 
     - script: |
+        export REVISION=$(Build.BuildId)
         make release
         make deb
       displayName: 'Building debian package & artifacts'
@@ -62,14 +61,13 @@ jobs:
     pool: 'Centos-Docker-Pool'
     dependsOn:
       - DEB_Package_Build
-    variables:
-      Revision: '$(Build.BuildId)'
     steps:
       - script: |
           make
         displayName: "Build Procdump Centos"
 
       - script: |
+          export REVISION=$(Build.BuildId)
           make release
           make rpm
         displayName: 'Building centos package & artifacts'


### PR DESCRIPTION
Changes Include:
 - Fixed auto-versioning for non AZDO builds & how BuildId is passed into debbuild/rpmbuild