### PR TITLE
Fix building with GCC 10

### DIFF
--- a/include/Logging.h
+++ b/include/Logging.h
@@ -26,8 +26,6 @@
 #define S2(x) S1(x)
 #define LOCATION "in "__FILE__ ", at line " S2(__LINE__)
 
-extern struct ProcDumpConfiguration g_config;
-
 
 enum LogLevel{
     debug,
@@ -39,7 +37,7 @@ enum LogLevel{
 
 void Log(enum LogLevel logLevel, const char *message, ...);
 
-pthread_mutex_t LoggerLock;
+extern pthread_mutex_t LoggerLock;
 
 void DiagTrace(const char* message, ...);
 

--- a/include/ProcDumpConfiguration.h
+++ b/include/ProcDumpConfiguration.h
@@ -38,10 +38,10 @@
 #define MIN_KERNEL_VERSION 3
 #define MIN_KERNEL_PATCH 5
 
-struct ProcDumpConfiguration g_config;  // backbone of the program
+extern struct ProcDumpConfiguration g_config;  // backbone of the program
 
-long HZ;                                // clock ticks per second
-int MAXIMUM_CPU;                        // maximum cpu usage percentage (# cores * 100)
+extern long HZ;                                // clock ticks per second
+extern int MAXIMUM_CPU;                        // maximum cpu usage percentage (# cores * 100)
 
 // -------------------
 // Structs

--- a/src/ProcDumpConfiguration.c
+++ b/src/ProcDumpConfiguration.c
@@ -12,6 +12,12 @@
 
 struct Handle g_evtConfigurationInitialized = HANDLE_MANUAL_RESET_EVENT_INITIALIZER("ConfigurationInitialized");
 
+pthread_mutex_t LoggerLock;
+struct ProcDumpConfiguration g_config;
+
+long HZ;
+int MAXIMUM_CPU;
+
 static sigset_t sig_set;
 static pthread_t sig_thread_id;
 


### PR DESCRIPTION
GCC 10 [defaults to `-fno-common`](https://gcc.gnu.org/gcc-10/porting_to.html#common) which requires us to explicitly mark global variables with `extern` in header files.