### PR TITLE
Fix to get child process PID's regardless of their process name.

### DIFF
--- a/tests/integration/runProcDumpAndValidate.sh
+++ b/tests/integration/runProcDumpAndValidate.sh
@@ -17,7 +17,7 @@ function runProcDumpAndValidate {
 
 		sleep 1s
 
-		childrenpid=$(pidof -o $pid stress-ng)
+		childrenpid=$(pidof -o $pid $(which stress-ng))
 			echo "ChildrenPID: $childrenpid"
 
 		childpid=$(echo $childrenpid | cut -d " " -f1)


### PR DESCRIPTION
The Debian executable `stress-ng` is build with the options `HAVE_BSD_UNISTD_H` and `HAVE_SETPROCTITLE`. Those options
enables setting the process name to the stressor name.

Related `makeconfig` checks are
```
make -f Makefile.config --no-print-directory HAVE_CONFIG=1 HEADER=bsd/unistd.h have_header_h
make -f Makefile.config --no-print-directory HAVE_CONFIG=1 TEST_LIBS=-lbsd TEST_PROG=test-setproctitle have_test_prog
```

This change was introduced in `stress-ng` release V0.10.13 (see commit [#f224f5db5](https://kernel.ubuntu.com/git/cking/stress-ng.git/commit/?id=f224f5db5)).

Hence for example for the execution of `stress-ng -c 1 -l 20 --timeout 20s -q` the process names reported by `ps` are different

**stress-ng before V0.10.13**
```
stress-ng -c 1 -l 20 --timeout 20s -q
stress-ng -c 1 -l 20 --timeout 20s -q
```

**stress-ng from V0.10.13**
```
stress-ng -c 1 -l 20 --timeout 20s -q
stress-ng-cpu
```

Those changed process names are the reason why `runProcDumpAndValidate.sh` fails to find the children PID.
As the command to find the children PID does not cover the child processes.
```
childrenpid=$(pidof -o $pid stress-ng)
```

This PR fixes #97.