### PR TITLE
ProcDumpConfiguration: fix crash in getopt_long

### DIFF
--- a/src/ProcDumpConfiguration.c
+++ b/src/ProcDumpConfiguration.c
@@ -194,7 +194,8 @@ int GetOptions(struct ProcDumpConfiguration *self, int argc, char *argv[])
         { "filedescriptors",           required_argument,  NULL,           'F' },                
         { "pollinginterval",           required_argument,  NULL,           'I' },                        
         { "diag",                      no_argument,        NULL,           'd' },
-        { "help",                      no_argument,        NULL,           'h' }
+        { "help",                      no_argument,        NULL,           'h' },
+        { NULL,                        0,                  NULL,            0  }
     };
 
     // start parsing command line arguments


### PR DESCRIPTION
As reported in #92, parsing the command line parameters can currently lead to a crash in `getopt_long`. This is caused by a missing terminating entry in the `long_options` array which is required as described in the man page for getopt_long [1].  Without this entry, getopt_long continues to parse garbage values on the stack as options.

Adding the missing entry fixes the crash.

[1]: `The last element of the array has to be filled with zeros.`

Fixes: #92