### PR TITLE
Fix clang compilation errors due to variable length arrays

### DIFF
--- a/sym/bcc_proc.cpp
+++ b/sym/bcc_proc.cpp
@@ -476,8 +476,8 @@ static bool which_so_in_process(const char* libname, int pid, char* libpath) {
   char endline[4096], *mapname = NULL, *newline;
   char mappings_file[128];
   const size_t search_len = strlen(libname) + strlen("/lib.");
-  char search1[search_len + 1];
-  char search2[search_len + 1];
+  char *search1 = new char[search_len + 1];
+  char *search2 = new char[search_len + 1];
 
   snprintf(mappings_file, sizeof(mappings_file), "/proc/%ld/maps", (long)pid);
   FILE *fp = fopen(mappings_file, "r");
@@ -507,28 +507,36 @@ static bool which_so_in_process(const char* libname, int pid, char* libpath) {
     }
   } while (ret != EOF);
 
+  delete[] search1;
+  delete[] search2;
+
   fclose(fp);
   return found;
 }
 
 char *bcc_procutils_which_so(const char *libname, int pid) {
   const size_t soname_len = strlen(libname) + strlen("lib.so");
-  char soname[soname_len + 1];
+  char *soname = new char[soname_len + 1];
+  char *ret = NULL;
   char libpath[4096];
   int i;
 
-  if (strchr(libname, '/'))
-    return strdup(libname);
+  if (strchr(libname, '/')) {
+    ret = strdup(libname);
+    goto done;
+  }
 
-  if (pid && which_so_in_process(libname, pid, libpath))
-    return strdup(libpath);
+  if (pid && which_so_in_process(libname, pid, libpath)) {
+    ret = strdup(libpath);
+    goto done;
+  }
 
   if (lib_cache_count < 0)
-    return NULL;
+    goto done;
 
   if (!lib_cache_count && load_ld_cache(LD_SO_CACHE) < 0) {
     lib_cache_count = -1;
-    return NULL;
+    goto done;
   }
 
   snprintf(soname, soname_len + 1, "lib%s.so", libname);
@@ -536,10 +544,14 @@ char *bcc_procutils_which_so(const char *libname, int pid) {
   for (i = 0; i < lib_cache_count; ++i) {
     if (!strncmp(lib_cache[i].libname, soname, soname_len) &&
         match_so_flags(lib_cache[i].flags)) {
-      return strdup(lib_cache[i].path);
+      ret = strdup(lib_cache[i].path);
+      goto done;
     }
   }
-  return NULL;
+
+done:
+  delete[] soname;
+  return ret;
 }
 
 void bcc_procutils_free(const char *ptr) {


### PR DESCRIPTION
I got some errors while I was compiling ProcDump 3.3. This PR just fix some of the compilation errors produced by Clang.

```
[ 46%] Building CXX object CMakeFiles/procdump.dir/sym/bcc_proc.cpp.o
/webhooks/ProcDump-for-Linux/sym/bcc_proc.cpp:479:16: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  479 |   char search1[search_len + 1];
      |                ^~~~~~~~~~~~~~
/webhooks/ProcDump-for-Linux/sym/bcc_proc.cpp:479:16: note: initializer of 'search_len' is not a constant expression
/webhooks/ProcDump-for-Linux/sym/bcc_proc.cpp:478:16: note: declared here
  478 |   const size_t search_len = strlen(libname) + strlen("/lib.");
      |                ^
/webhooks/ProcDump-for-Linux/sym/bcc_proc.cpp:480:16: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  480 |   char search2[search_len + 1];
      |                ^~~~~~~~~~~~~~
/webhooks/ProcDump-for-Linux/sym/bcc_proc.cpp:480:16: note: initializer of 'search_len' is not a constant expression
/webhooks/ProcDump-for-Linux/sym/bcc_proc.cpp:478:16: note: declared here
  478 |   const size_t search_len = strlen(libname) + strlen("/lib.");
      |                ^
/webhooks/ProcDump-for-Linux/sym/bcc_proc.cpp:516:15: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  516 |   char soname[soname_len + 1];
      |               ^~~~~~~~~~~~~~
/webhooks/ProcDump-for-Linux/sym/bcc_proc.cpp:516:15: note: initializer of 'soname_len' is not a constant expression
/webhooks/ProcDump-for-Linux/sym/bcc_proc.cpp:515:16: note: declared here
  515 |   const size_t soname_len = strlen(libname) + strlen("lib.so");
      |                ^
3 errors generated.
make[2]: *** [CMakeFiles/procdump.dir/build.make:248: CMakeFiles/procdump.dir/sym/bcc_proc.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:178: CMakeFiles/procdump.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

There are some occurrences of variable length arrays. We need to change them to dynamic allocation to avoid runtime memory issues. This commit just fix some of those occurrences by using C++ dynamic memory allocation.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>