### PR TITLE
Monitor: removed useless variables

### DIFF
--- a/src/Monitor.cpp
+++ b/src/Monitor.cpp
@@ -1319,8 +1319,6 @@ void *CpuMonitoringThread(void *thread_args /* struct ProcDumpConfiguration* */)
     Trace("CpuMonitoringThread: Enter [id=%d]", gettid());
     struct ProcDumpConfiguration *config = (struct ProcDumpConfiguration *)thread_args;
 
-    unsigned long totalTime = 0;
-    unsigned long elapsedTime = 0;
     int cpuUsage;
     auto_free struct CoreDumpWriter *writer = NULL;
     auto_free char* dumpFileName = NULL;


### PR DESCRIPTION
There are some variables in `CpuMonitoringThread()` function that are not being used. This is causing compilation issues by clang.

For further reference of the error, see the log below:

```[ 90%] Building CXX object CMakeFiles/procdump.dir/sym/bcc_elf.cpp.o
clang++  -I/root/rpmbuild/BUILD/procdump-3.4.0-build/ProcDump-for-Linux-3.4.0/include -I/root/rpmbuild/BUILD/procdump-3.4.0-build/ProcDump-for-Linux-3.4.0/redhat-linux-build -I/root/rpmbuild/BUILD/procdump-3.4.0-build/ProcDump-for-Linux-3.4.0/sym -I/root/rpmbuild/BUILD/procdump-3.4.0-build/ProcDump-for-Linux-3.4.0/ebpf -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS    -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -pthread -fstack-protector-all -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Werror -D_GNU_SOURCE -std=c++11 -O2 -DWITH_GZFILEOP -MD -MT CMakeFiles/procdump.dir/sym/bcc_elf.cpp.o -MF CMakeFiles/procdump.dir/sym/bcc_elf.cpp.o.d -o CMakeFiles/procdump.dir/sym/bcc_elf.cpp.o -c /root/rpmbuild/BUILD/procdump-3.4.0-build/ProcDump-for-Linux-3.4.0/sym/bcc_elf.cpp
/root/rpmbuild/BUILD/procdump-3.4.0-build/ProcDump-for-Linux-3.4.0/src/Monitor.cpp:1322:19: error: unused variable 'totalTime' [-Werror,-Wunused-variable]
 1322 |     unsigned long totalTime = 0;
      |                   ^~~~~~~~~
/root/rpmbuild/BUILD/procdump-3.4.0-build/ProcDump-for-Linux-3.4.0/src/Monitor.cpp:1323:19: error: unused variable 'elapsedTime' [-Werror,-Wunused-variable]
 1323 |     unsigned long elapsedTime = 0;
      |                   ^~~~~~~~~~~
2 errors generated.
```