### PR TITLE
Checks whether gcore is in PATH when trigger is not .NET or restrack nodump

### DIFF
--- a/include/GenHelpers.h
+++ b/include/GenHelpers.h
@@ -125,6 +125,7 @@ char *sanitize(char *processName);
 int StringToGuid(char* szGuid, struct CLSID* pGuid);
 int GetHex(char* szStr, int size, void* pResult);
 bool createDir(const char *dir, mode_t perms);
+bool isBinaryOnPath(const char *binary);
 char* GetSocketPath(char* prefix, pid_t pid, pid_t targetPid);
 int send_all(int socket, void *buffer, size_t length);
 int recv_all(int socket, void* buffer, size_t length);

--- a/src/GenHelpers.cpp
+++ b/src/GenHelpers.cpp
@@ -489,24 +489,34 @@ bool isBinaryOnPath(const char *binary){
     char binbuf[4096];
     struct stat statbuf;
 
-    char *path = getenv("PATH");
-    if(path == NULL)
+    char *PATH = getenv("PATH");
+    if(PATH == NULL)
     {
         return false;
     }
 
-    char* directory = strtok(path, ":");
+    char *path = strdup(PATH);
+    if(path == NULL)
+    {
+        Log(error, INTERNAL_ERROR);
+        Trace("isBinaryOnPath: failed to strdup PATH");
+        return false;
+    }
+
+    char *directory = strtok(path, ":");
     while (directory != NULL)
     {
         snprintf(binbuf, sizeof(binbuf), "%s/%s", directory, binary);
         if (stat(binbuf, &statbuf) == 0 && S_ISREG(statbuf.st_mode))
         {
+            free(path);
             return true;
         }
         
         directory = strtok(NULL, ":");
     }
 
+    free(path);
     return false;
 }
 

--- a/src/GenHelpers.cpp
+++ b/src/GenHelpers.cpp
@@ -480,6 +480,38 @@ bool createDir(const char *dir, mode_t perms)
 
 //--------------------------------------------------------------------
 //
+// isBinaryOnPath
+//
+// Checks whether a binary can be found in any of the directories from the PATH.
+//
+//--------------------------------------------------------------------
+bool isBinaryOnPath(const char *binary){
+    char binbuf[4096];
+    struct stat statbuf;
+
+    char *path = getenv("PATH");
+    if(path == NULL)
+    {
+        return false;
+    }
+
+    char* directory = strtok(path, ":");
+    while (directory != NULL)
+    {
+        snprintf(binbuf, sizeof(binbuf), "%s/%s", directory, binary);
+        if (stat(binbuf, &statbuf) == 0 && S_ISREG(statbuf.st_mode))
+        {
+            return true;
+        }
+        
+        directory = strtok(NULL, ":");
+    }
+
+    return false;
+}
+
+//--------------------------------------------------------------------
+//
 // GetSocketPath
 //
 //--------------------------------------------------------------------

--- a/src/ProcDumpConfiguration.cpp
+++ b/src/ProcDumpConfiguration.cpp
@@ -1037,6 +1037,15 @@ int GetOptions(struct ProcDumpConfiguration *self, int argc, char *argv[])
         return PrintUsage();
     }
 
+    // Except for Restrack with -nodump option and .NET triggers, all other triggers use gdb/gcore
+    if(self->bRestrackEnabled && self->bRestrackGenerateDump || dotnetTriggerCount == 0)
+    {
+        if(!isBinaryOnPath("gcore")){
+            Log(error, "failed to locate gcore binary in $PATH. Check that gdb/gcore is installed and configured on your system.");
+            return -1;
+        }
+    }
+
     // Apply default values for any config values that were not specified by user
     ApplyDefaults(self);
 

--- a/src/ProcDumpConfiguration.cpp
+++ b/src/ProcDumpConfiguration.cpp
@@ -1037,9 +1037,8 @@ int GetOptions(struct ProcDumpConfiguration *self, int argc, char *argv[])
         return PrintUsage();
     }
 
-    // Except for Restrack with -nodump option and .NET triggers, all other triggers use gdb/gcore
-    if(self->bRestrackEnabled && self->bRestrackGenerateDump || dotnetTriggerCount == 0)
-    {
+    // Except for .NET triggers and Restrack with 'nodump' option, all other triggers use gdb/gcore
+    if(dotnetTriggerCount == 0 && !(self->bRestrackEnabled && !self->bRestrackGenerateDump)){
         if(!isBinaryOnPath("gcore")){
             Log(error, "failed to locate gcore binary in $PATH. Check that gdb/gcore is installed and configured on your system.");
             return -1;

--- a/tests/integration/scenarios/missing_gcore.sh
+++ b/tests/integration/scenarios/missing_gcore.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
+PROCDUMPPATH="$DIR/../../../procdump";
+
+
+GCORE=$(which gcore)
+echo [`date +"%T.%3N"`] Moving gcore from $GCORE to /tmp/gcore
+mv $GCORE /tmp/gcore
+
+echo [`date +"%T.%3N"`] Starting ProcDump
+output=$($PROCDUMPPATH "123")
+
+echo [`date +"%T.%3N"`] Restoring gcore from tmp/gcore to $GCORE
+mv /tmp/gcore $GCORE
+
+
+expected="failed to locate gcore binary"
+if [[ "$output" == *"$expected"* ]]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
Following #275, this PR adds a verification right after the command line options are parsed to check that, in case the trigger is not .NET or restrack nodump, the `gcore` command is available in the PATH.