### PR TITLE
fix segmentation fault when gcore script doesn't output anything

### DIFF
--- a/src/CoreDumpWriter.cpp
+++ b/src/CoreDumpWriter.cpp
@@ -347,7 +347,7 @@ char* WriteCoreDumpInternal(struct CoreDumpWriter *self, char* socketName)
         bool gcoreFailedMsg = false;    // in case error sneaks through the message output
 
         // check if gcore was able to generate the dump
-        if(outputBuffer[i-1] != NULL)
+        if(i > 0 && outputBuffer[i-1] != NULL)
         {
             if(strstr(outputBuffer[i-1], "gcore: failed") != NULL)
             {


### PR DESCRIPTION
When gcore script doesn't output anything, there was a segmentation fault when accessing the output buffer. 