### PR TITLE
Waiting for sockets and dumps to be written

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,10 +62,10 @@ extends:
 
           - template: templates/build.yaml@ProcDump
 
-          # - script: |
-          #     cd procdump_build/tests/integration
-          #     ./run.sh
-          #   displayName: 'Run unit tests'
+          - script: |
+              cd procdump_build/tests/integration
+              ./run.sh
+            displayName: 'Run unit tests'
 
         - job: "ProcDump_Build_AMD64_Run_Tests"
           pool:

--- a/profiler/src/ProcDumpProfiler.cpp
+++ b/profiler/src/ProcDumpProfiler.cpp
@@ -307,6 +307,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::InitializeForAttach(IUnknown *pCorProfile
     // Create the health check thread which periodically pings procdump to see if its still alive
     pthread_create(&healthThread, NULL, HealthThread, this);
 
+    // The following output is used in integration tests (tests/integration/helpers.sh) 
+    LOG(TRACE) << "CorProfiler::InitializeForAttach: Initialization complete (procdumppid=" << procDumpPid << ",targetpid=" << getpid() << ")";
+
     LOG(TRACE) << "CorProfiler::InitializeForAttach: Exit";
     return S_OK;
 }

--- a/src/Monitor.cpp
+++ b/src/Monitor.cpp
@@ -1990,6 +1990,8 @@ void *WaitForProfilerCompletion(void *thread_args /* struct ProcDumpConfiguratio
             return NULL;
         }
 
+        Trace("WaitForProfilerCompletion: Connection was accepted");
+
         // packet looks like this: <payload_len><[byte] 0=failure, 1=success><[uint_32] dumpfile_path_len><[char*]Dumpfile path>
         int payloadLen = 0;
         if(recv_all(s2, &payloadLen, sizeof(int))==-1)

--- a/src/ProfilerHelpers.cpp
+++ b/src/ProfilerHelpers.cpp
@@ -251,6 +251,8 @@ int LoadProfiler(pid_t pid, char* clientData)
 //--------------------------------------------------------------------
 int InjectProfiler(pid_t pid, char* clientData)
 {
+    Trace("InjectProfiler: Starting injection of profiler into target process %d", pid);
+
     int ret = ExtractProfiler();
     if(ret != 0)
     {
@@ -266,6 +268,8 @@ int InjectProfiler(pid_t pid, char* clientData)
         Trace("InjectProfiler: failed to load profiler into target process.");
         return ret;
     }
+
+    Trace("InjectProfiler: Successfully injected profiler into target process %d", pid);
 
     return 0;
 }

--- a/tests/integration/helpers.sh
+++ b/tests/integration/helpers.sh
@@ -106,13 +106,15 @@ function waitforndumps {
   local dumppattern=$2
   local -n result=$3
 
-  for i in {1..15}; do
-      result=( $(ls $dumppattern | wc -l) )
-      if [[ "$result" -ge $expecteddumps ]]; then
-          echo "[script] Dump was written..."
-          break
-      fi
-      echo "[script] Waiting for dump to be written..."
-      sleep 1
+  for i in {1..30}; do
+    files=( $dumppattern )
+    result=${#files[@]}
+    if [ "$result" -ge "$expecteddumps" ]; then
+        echo "[script] Dump was written..."
+        break
+    fi
+    echo "[script] Waiting for dump to be written..."
+    sleep 1
   done
 }
+

--- a/tests/integration/helpers.sh
+++ b/tests/integration/helpers.sh
@@ -84,4 +84,33 @@ function waitforprocdumpsocket {
   sudo ls /tmp/procdump
   echo "ProcDump .NET status socket found"
   result=$socketpath
+
+  # wait for profile to be loaded
+  for i in {1..15}; do
+      PROF="$(cat /proc/${testchildpid}/maps | awk '{print $6}' | grep '\procdumpprofiler.so' | uniq)"
+      if [[ "$PROF" == *"procdumpprofiler.so" ]]; then
+          echo "[script] Profiler was loaded..."
+          break
+      fi
+      echo "[script] Waiting for profiler to be loaded..."
+      sleep 1
+  done
+}
+
+#
+# wait for dump to be created/written
+#
+function waitfordump {
+  local dumppattern=$1
+  local -n result=$2
+
+  for i in {1..15}; do
+      result=( $(ls $dumppattern | wc -l) )
+      if [[ "$result" -eq 1 ]]; then
+          echo "[script] Dump was written..."
+          break
+      fi
+      echo "[script] Waiting for dump to be written..."
+      sleep 1
+  done
 }

--- a/tests/integration/scenarios/dotnet_0ExceptionDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_0ExceptionDump1Thrown_dump.sh
@@ -50,7 +50,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
-waitfordump *TestWebApi_*Exception* "COUNT"
+waitforndumps 1 *TestWebApi_*Exception* "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_0ExceptionDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_0ExceptionDump1Thrown_dump.sh
@@ -50,7 +50,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
-waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+waitforndumps 1 "*TestWebApi_*Exception*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_0ExceptionDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_0ExceptionDump1Thrown_dump.sh
@@ -48,29 +48,9 @@ if [ $SOCKETPATH -eq -1 ]; then
 fi
 echo "SOCKETPATH: "$SOCKETPATH
 
-# wait for profile to be loaded
-for i in {1..15}; do
-    PROF="$(cat /proc/${TESTCHILDPID}/maps | awk '{print $6}' | grep '\procdumpprofiler.so' | uniq)"
-    if [[ "$PROF" == *"procdumpprofiler.so" ]]; then
-        echo "[script] Profiler was loaded..."
-        break
-    fi
-    echo "[script] Waiting for profiler to be loaded..."
-    sleep 1
-done
-
 wget http://localhost:5032/throwinvalidoperation
 
-# wait for dump to be created
-for i in {1..15}; do
-    COUNT=( $(ls *TestWebApi_*Exception* | wc -l) )
-    if [[ "$COUNT" -eq 1 ]]; then
-        echo "[script] Dump was written..."
-        break
-    fi
-    echo "[script] Waiting for dump to be written..."
-    sleep 1
-done
+waitfordump *TestWebApi_*Exception* "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_0WildcardExceptionDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_0WildcardExceptionDump1Thrown_dump.sh
@@ -46,7 +46,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
-waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+waitforndumps 1 "*TestWebApi_*Exception*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_0WildcardExceptionDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_0WildcardExceptionDump1Thrown_dump.sh
@@ -46,8 +46,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
+waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*Exception* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_1FilterExceptionMsgDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_1FilterExceptionMsgDump1Thrown_dump.sh
@@ -46,7 +46,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
-waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+waitforndumps 1 "*TestWebApi_*Exception*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_1FilterExceptionMsgDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_1FilterExceptionMsgDump1Thrown_dump.sh
@@ -46,8 +46,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
+waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*Exception* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_1WildcardExceptionDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_1WildcardExceptionDump1Thrown_dump.sh
@@ -46,7 +46,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
-waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+waitforndumps 1 "*TestWebApi_*Exception*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_1WildcardExceptionDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_1WildcardExceptionDump1Thrown_dump.sh
@@ -46,8 +46,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
+waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*Exception* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_1WildcardFilterExceptionMsgDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_1WildcardFilterExceptionMsgDump1Thrown_dump.sh
@@ -46,7 +46,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
-waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+waitforndumps 1 "*TestWebApi_*Exception*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_1WildcardFilterExceptionMsgDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_1WildcardFilterExceptionMsgDump1Thrown_dump.sh
@@ -46,8 +46,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
+waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*Exception* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_1_gc_gen_1_dump.sh
+++ b/tests/integration/scenarios/dotnet_1_gc_gen_1_dump.sh
@@ -47,7 +47,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/fullgc
 
-waitforndumps 2 *TestWebApi_*gc_gen_* "COUNT"
+waitforndumps 2 "*TestWebApi_*gc_gen_*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_1_gc_gen_1_dump.sh
+++ b/tests/integration/scenarios/dotnet_1_gc_gen_1_dump.sh
@@ -47,8 +47,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/fullgc
 
+waitforndumps 2 *TestWebApi_*gc_gen_* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*gc_gen_* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_1_gc_threshold_1_dump.sh
+++ b/tests/integration/scenarios/dotnet_1_gc_threshold_1_dump.sh
@@ -47,7 +47,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/memincrease
 
-waitforndumps 1 *TestWebApi_*gc_size_* "COUNT"
+waitforndumps 1 "*TestWebApi_*gc_size_*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_1_gc_threshold_1_dump.sh
+++ b/tests/integration/scenarios/dotnet_1_gc_threshold_1_dump.sh
@@ -47,8 +47,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/memincrease
 
+waitforndumps 1 *TestWebApi_*gc_size_* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*gc_size_* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_1exceptionDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_1exceptionDump1Thrown_dump.sh
@@ -46,7 +46,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
-waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+waitforndumps 1 "*TestWebApi_*Exception*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_1exceptionDump1Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_1exceptionDump1Thrown_dump.sh
@@ -46,8 +46,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget http://localhost:5032/throwinvalidoperation
 
+waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*Exception* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_1exceptionDump2Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_1exceptionDump2Thrown_dump.sh
@@ -47,7 +47,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 wget http://localhost:5032/throwinvalidoperation
 wget http://localhost:5032/throwinvalidoperation
 
-waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+waitforndumps 1 "*TestWebApi_*Exception*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_1exceptionDump2Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_1exceptionDump2Thrown_dump.sh
@@ -47,8 +47,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 wget http://localhost:5032/throwinvalidoperation
 wget http://localhost:5032/throwinvalidoperation
 
+waitforndumps 1 *TestWebApi_*Exception* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*Exception* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_2WildcardExceptionDump2Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_2WildcardExceptionDump2Thrown_dump.sh
@@ -47,7 +47,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 wget http://localhost:5032/throwinvalidoperation
 wget http://localhost:5032/throwinvalidoperation
 
-waitforndumps 2 *TestWebApi_*Exception* "COUNT"
+waitforndumps 2 "*TestWebApi_*Exception*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_2WildcardExceptionDump2Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_2WildcardExceptionDump2Thrown_dump.sh
@@ -47,8 +47,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 wget http://localhost:5032/throwinvalidoperation
 wget http://localhost:5032/throwinvalidoperation
 
+waitforndumps 2 *TestWebApi_*Exception* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*Exception* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_2exceptionDump2Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_2exceptionDump2Thrown_dump.sh
@@ -47,7 +47,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 wget http://localhost:5032/throwinvalidoperation
 wget http://localhost:5032/throwinvalidoperation
 
-waitforndumps 2 *TestWebApi_*Exception* "COUNT"
+waitforndumps 2 "*TestWebApi_*Exception*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_2exceptionDump2Thrown_dump.sh
+++ b/tests/integration/scenarios/dotnet_2exceptionDump2Thrown_dump.sh
@@ -47,8 +47,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 wget http://localhost:5032/throwinvalidoperation
 wget http://localhost:5032/throwinvalidoperation
 
+waitforndumps 2 *TestWebApi_*Exception* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*Exception* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_3_gc_thresholds_3_dumps.sh
+++ b/tests/integration/scenarios/dotnet_3_gc_thresholds_3_dumps.sh
@@ -47,7 +47,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/memincrease
 
-waitforndumps 3 *TestWebApi_*gc_size_* "COUNT"
+waitforndumps 3 "*TestWebApi_*gc_size_*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_3_gc_thresholds_3_dumps.sh
+++ b/tests/integration/scenarios/dotnet_3_gc_thresholds_3_dumps.sh
@@ -47,8 +47,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/memincrease
 
+waitforndumps 3 *TestWebApi_*gc_size_* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*gc_size_* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_LOH_thresholds_3_dumps.sh
+++ b/tests/integration/scenarios/dotnet_LOH_thresholds_3_dumps.sh
@@ -47,7 +47,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/memincrease
 
-waitforndumps 3 *TestWebApi_*gc_size_* "COUNT"
+waitforndumps 3 "*TestWebApi_*gc_size_*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_LOH_thresholds_3_dumps.sh
+++ b/tests/integration/scenarios/dotnet_LOH_thresholds_3_dumps.sh
@@ -47,8 +47,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/memincrease
 
+waitforndumps 3 *TestWebApi_*gc_size_* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*gc_size_* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_POH_thresholds_3_dumps.sh
+++ b/tests/integration/scenarios/dotnet_POH_thresholds_3_dumps.sh
@@ -47,7 +47,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/memincrease
 
-waitforndumps 3 *TestWebApi_*gc_size_* "COUNT"
+waitforndumps 3 "*TestWebApi_*gc_size_*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_POH_thresholds_3_dumps.sh
+++ b/tests/integration/scenarios/dotnet_POH_thresholds_3_dumps.sh
@@ -47,8 +47,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/memincrease
 
+waitforndumps 3 *TestWebApi_*gc_size_* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*gc_size_* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH

--- a/tests/integration/scenarios/dotnet_gen_2_thresholds_3_dumps.sh
+++ b/tests/integration/scenarios/dotnet_gen_2_thresholds_3_dumps.sh
@@ -47,7 +47,7 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/memincrease
 
-waitforndumps 3 *TestWebApi_*gc_size_* "COUNT"
+waitforndumps 3 "*TestWebApi_*gc_size_*" "COUNT"
 
 sudo pkill -9 procdump
 

--- a/tests/integration/scenarios/dotnet_gen_2_thresholds_3_dumps.sh
+++ b/tests/integration/scenarios/dotnet_gen_2_thresholds_3_dumps.sh
@@ -47,8 +47,10 @@ echo "SOCKETPATH: "$SOCKETPATH
 
 wget -O /dev/null http://localhost:5032/memincrease
 
+waitforndumps 3 *TestWebApi_*gc_size_* "COUNT"
+
 sudo pkill -9 procdump
-COUNT=( $(ls *TestWebApi_*gc_size_* | wc -l) )
+
 if [ -S $SOCKETPATH ];
 then
     rm $SOCKETPATH


### PR DESCRIPTION
This pull request improves integration test reliability and observability for the ProcDump .NET profiler by adding explicit checks for profiler initialization and dump file creation. It also enhances logging in the profiler and related helper functions to aid debugging and test diagnostics.