### PR TITLE
Compiler fixes for ProcDump

### DIFF
--- a/src/Monitor.cpp
+++ b/src/Monitor.cpp
@@ -1605,7 +1605,7 @@ void* RestrackManualTriggerThread(void *thread_args /* struct ProcDumpConfigurat
 #ifdef __linux__
     struct ProcDumpConfiguration *config = (struct ProcDumpConfiguration *)thread_args;
 
-    struct TerminalState originalTerminalState = {0};
+    struct TerminalState originalTerminalState = {{}};
     auto_free struct CoreDumpWriter *writer = NULL;
     std::vector<pthread_t> leakReportThreads;
     int rc = 0;

--- a/tests/integration/ProcDumpTestApplication.c
+++ b/tests/integration/ProcDumpTestApplication.c
@@ -82,16 +82,13 @@ void* ThreadProc(void *input)
 
 // CPU stress function - consumes specified percentage of CPU
 void stress_cpu(int target_cpu_percentage) {
-    struct timespec work_time, sleep_time;
+    struct timespec sleep_time;
     long work_usec, sleep_usec;
     
     // Calculate work and sleep times for desired CPU percentage
     // Use 10ms cycle time for good responsiveness
     work_usec = (10000 * target_cpu_percentage) / 100;
     sleep_usec = 10000 - work_usec;
-    
-    work_time.tv_sec = work_usec / 1000000;
-    work_time.tv_nsec = (work_usec % 1000000) * 1000;
     
     sleep_time.tv_sec = sleep_usec / 1000000;
     sleep_time.tv_nsec = (sleep_usec % 1000000) * 1000;


### PR DESCRIPTION
This PR basically fixes two compilation errors in ProcDump 3.5.0. The first one is an unused variable inside the function `stress_cpu`, and the other error is just a malformed variable initialization.

The first report is:

```bash
gmake[2]: Leaving directory '/root/rpmbuild/BUILD/procdump-3.5.0-build/ProcDump-for-Linux-3.5.0/redhat-linux-build'
/root/rpmbuild/BUILD/procdump-3.5.0-build/ProcDump-for-Linux-3.5.0/tests/integration/ProcDumpTestApplication.c: In function ‘stress_cpu’:
/root/rpmbuild/BUILD/procdump-3.5.0-build/ProcDump-for-Linux-3.5.0/tests/integration/ProcDumpTestApplication.c:85:21: error: variable ‘work_time’ set but not used [-Werror=unused-but-set-variable]
   85 |     struct timespec work_time, sleep_time;
      |                     ^~~~~~~~~
```

And the second one is:

```bash
/root/rpmbuild/BUILD/procdump-3.5.0-build/ProcDump-for-Linux-3.5.0/src/Monitor.cpp:1608:51: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
 1608 |     struct TerminalState originalTerminalState = {0};
      |                                                   ^
      |                                                   {}
```